### PR TITLE
sdm845-common: overlay: Enable burn in protection for status/navbar

### DIFF
--- a/overlay-aosip/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay-aosip/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -18,4 +18,8 @@
 <resources>
     <!-- Allow devices override audio panel location to the left side -->
     <bool name="config_audioPanelOnLeftSide">true</bool>
+
+    <!-- Burn in protection -->
+    <bool name="config_statusBarBurnInProtection">true</bool>
+    <integer name="config_shift_interval">40</integer>
 </resources>


### PR DESCRIPTION
Also set shift interval to 40 instead of default 60 since HBM mode is a thing on OP sdm845
Signed-off-by: Anirudh Gupta <anirudhgupta109@gmail.com>